### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+**/.git
+.gitattributes
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM alpine:3.9 as build-stage
+# Install build dependencies
+RUN apk --no-cache \
+    add --virtual build-dependencies \
+    wget \
+    tar \
+    make \
+    diffutils \
+    texinfo \
+    gcc \
+    g++ \
+    lua5.3-dev \
+    jansson-dev \
+    libusb-dev
+# Prepare workspace
+WORKDIR /usr/local/src/n64
+COPY . .
+RUN LDFLAGS="-L/usr/lib/lua5.3" ./configure \
+    --prefix=/opt/n64 \
+    --enable-vc
+RUN make install-toolchain -j`cat /proc/cpuinfo | grep processor | wc -l`
+# Compile and install
+RUN make \
+    && make install \
+    && make install-sys
+
+# Final image
+FROM alpine:3.9
+RUN apk --no-cache add \
+    make \
+    lua5.3 \
+    jansson \
+    libusb
+COPY --from=build-stage /opt/n64 /usr/local
+CMD ["/bin/sh"]


### PR DESCRIPTION
# Add Dockerfile - Pull Request
This pull request adds a dockerfile to the repository. Using this it is possible to build an image with e.g. `docker build --tag n64 .` if docker is installed on the machine. This image can be used to run a container with `docker run --interactive --tty --rm n64`. From there it is possible to easily clone, build and run gz for example.

## Background
It can be cumbersome to maintain a clean and working environment for the N64 environment. Cluttering the system with N64 compilation dependencies and having small version conflicts with libraries and similar can happen from time to time.

## Suggested Solution
Utilize a platform as a service using operating-system-level virtualization with containers. It does not matter which OS and which configuration the usage machine has. As long as it can run the container it will have a predictable and isolated environment. [Docker](https://www.docker.com/resources/what-container) is such a solution.