### PR TITLE
Add padding to grc_texture

### DIFF
--- a/include/grc.h
+++ b/include/grc.h
@@ -19,6 +19,7 @@ struct grc_texture
   uint16_t  tile_height;
   uint16_t  tiles_x;
   uint16_t  tiles_y;
+  uint16_t  pad;
   char      texture_data[];
 };
 


### PR DESCRIPTION
Add 2 byte padding to grc_texture to force 64-bit alignment on texture_data