### PR TITLE
Add Lua 5.4 compatibility to configure and configure.ac.

### DIFF
--- a/configure
+++ b/configure
@@ -3914,7 +3914,7 @@ return luaopen_utf8 ();
   return 0;
 }
 _ACEOF
-for ac_lib in '' lua-5.3 lua5.3 lua; do
+for ac_lib in '' lua-5.4 lua5.4 lua-5.3 lua5.3 lua; do
   if test -z "$ac_lib"; then
     ac_res="none required"
   else
@@ -4243,7 +4243,7 @@ fi
 
 
 # Checks for header files.
-for ac_header in lua5.3/lua.h lua53/lua.h lua.h
+for ac_header in lua5.4/lua.h lua54/lua.h lua5.3/lua.h lua53/lua.h lua.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"

--- a/configure.ac
+++ b/configure.ac
@@ -76,7 +76,7 @@ AC_SUBST([LIBUTIL])
 AC_SUBST([LIBWS2_32])
 AC_SEARCH_LIBS([pow], [m],
                [AS_IF([test -n "$ac_lib"], [LIBM=-l$ac_lib])])
-AC_SEARCH_LIBS([luaopen_utf8], [lua-5.3 lua5.3 lua],
+AC_SEARCH_LIBS([luaopen_utf8], [lua-5.4 lua5.4 lua-5.3 lua5.3 lua],
                [AS_IF([test -n "$ac_lib"], [LIBLUA=-l$ac_lib])])
 AC_SEARCH_LIBS([libusb_init], [usb-1.0 usb],
                [AS_IF([test -n "$ac_lib"], [LIBUSB=-l$ac_lib])],
@@ -92,7 +92,7 @@ AC_SEARCH_LIBS([gai_strerrorA], [Ws2_32],
                [AS_IF([test -n "$ac_lib"], [LIBWS2_32=-l$ac_lib])])
 
 # Checks for header files.
-AC_CHECK_HEADERS([lua5.3/lua.h lua53/lua.h lua.h])
+AC_CHECK_HEADERS([lua5.4/lua.h lua54/lua.h lua5.3/lua.h lua53/lua.h lua.h])
 AC_CHECK_HEADERS([libusb-1.0/libusb.h libusb.h])
 AC_CHECK_HEADERS([pty.h util.h libutil.h])
 


### PR DESCRIPTION
Fixes #12 

This restores the ability to build gru on my Fedora 33 machine with Lua 5.4.1. It may not be the most complete or most efficient approach to a solution, but it does at least seem to be working.