### PR TITLE
Force 8 byte alignment of grc textures

### DIFF
--- a/lib/gl-n64.ld
+++ b/lib/gl-n64.ld
@@ -83,6 +83,7 @@ SECTIONS
     __RESOURCE_LIST__ = . ;
     KEEP(*(.data.resource_table))
     __RESOURCE_END__ = . ;
+    . = ALIGN(8) ;
     KEEP(*(.data.resource_data))
     *(.data .data.*)
     *(.gnu.linkonce.d.*)


### PR DESCRIPTION
Force 8 byte alignment of grc textures.  