### PR TITLE
Allow setbits to be 0 for SetGeometryMode

### DIFF
--- a/src/gfxdis/gfxdis.c
+++ b/src/gfxdis/gfxdis.c
@@ -322,11 +322,19 @@ static int strarg_gm(char *buf, uint32_t arg)
   int p = 0;
   if (arg & G_ZBUFFER)
     strappf("G_ZBUFFER");
+#if defined(F3D_GBI) || defined(F3DEX_GBI)
+  // G_TEXTURE_ENABLE == 2
   if (arg & G_TEXTURE_ENABLE) {
     if (p > 0)
       strappf(" | ");
     strappf("G_TEXTURE_ENABLE");
   }
+#elif defined(F3DEX_GBI_2)
+  // G_TEXTURE_ENABLE == 0, so check against it directly
+  if (arg == G_TEXTURE_ENABLE) {
+    strappf("G_TEXTURE_ENABLE");
+  }
+#endif
   if (arg & G_SHADE) {
     if (p > 0)
       strappf(" | ");
@@ -3690,7 +3698,7 @@ int gfx_dis_spGeometryMode(struct gfx_insn *insn, uint32_t hi, uint32_t lo)
 {
   uint32_t clearbits = getfield(~hi, 24, 0);
   uint32_t setbits = lo;
-  if (clearbits == 0 && setbits != 0)
+  if (clearbits == 0)
     return gfx_dis_spSetGeometryMode(insn, hi, lo);
   else if (clearbits != 0 && setbits == 0)
     return gfx_dis_spClearGeometryMode(insn, hi, lo);


### PR DESCRIPTION
Some games use `D9FFFFFF00000000` for geometry modes, which currently fails to output correctly, giving `gSPGeometryMode(gfx++, , );` with empty arguments.

In f3dex2, G_TEXTURE_ENABLE is defined to be the value 0, whereas in f3dex and fast3d it's defined to be 2, and 0 is an invalid value. When trying to get the arg, strarg_gm tries to do `arg & 0` which can only result in false, and ends up not printing anything. This PR adds support for version 1 and 2's defines. Also removes the setbits requirement so we can get into SetGeometryMode. This command is always used right after ClearGeometryMode, so I think Set is the correct one to use here, and the `clearbits == 0` check is still unique.