### PR TITLE
Fix shift amount of size argument for SPDma_io and family

### DIFF
--- a/src/gfxdis/gfxdis.c
+++ b/src/gfxdis/gfxdis.c
@@ -3922,7 +3922,7 @@ int gfx_dis_spDma_io(struct gfx_insn *insn, uint32_t hi, uint32_t lo)
     insn->arg[0] = flag;
     insn->arg[1] = getfield(hi, 10, 13) * 8;
     insn->arg[2] = lo;
-    insn->arg[3] = getfield(hi, 12, 10) + 1;
+    insn->arg[3] = getfield(hi, 12, 0) + 1;
     insn->strarg[1] = strarg_x16;
     insn->strarg[2] = strarg_x32;
     insn->strarg[3] = strarg_x16;
@@ -3936,7 +3936,7 @@ int gfx_dis_spDmaRead(struct gfx_insn *insn, uint32_t hi, uint32_t lo)
   insn->n_gfx = 1;
   insn->arg[0] = getfield(hi, 10, 13) * 8;
   insn->arg[1] = lo;
-  insn->arg[2] = getfield(hi, 12, 10) + 1;
+  insn->arg[2] = getfield(hi, 12, 0) + 1;
   insn->strarg[0] = strarg_x16;
   insn->strarg[1] = strarg_x32;
   insn->strarg[2] = strarg_x16;
@@ -3949,7 +3949,7 @@ int gfx_dis_spDmaWrite(struct gfx_insn *insn, uint32_t hi, uint32_t lo)
   insn->n_gfx = 1;
   insn->arg[0] = getfield(hi, 10, 13) * 8;
   insn->arg[1] = lo;
-  insn->arg[2] = getfield(hi, 12, 10) + 1;
+  insn->arg[2] = getfield(hi, 12, 0) + 1;
   insn->strarg[0] = strarg_x16;
   insn->strarg[1] = strarg_x32;
   insn->strarg[2] = strarg_x16;


### PR DESCRIPTION
It should read from value bit 0 instead of bit 10

This can be seen in gbi.h from both ultralib repo and this same libgfxd repo:
https://github.com/decompals/ultralib/blob/8c4a939e6b607a08628e3b3844f5ce776c754cb5/include/PR/gbi.h#L2426-L2431
https://github.com/glankk/libgfxd/blob/37e3f7ef71cbf66263064c0e1b9484a744c06cf8/gbi.h#L2973-L2979

Currently `gfxdis` produces the following output:
```c
$ gfxdis.f3dex2 -d D619E013 88888888
{
    gsSPDmaRead(0x0678, 0x88888888, 0x0679),
}
```

When the original macro looks like this
```c
    gsSPDmaRead(0x0678, 0x88888888, 0x14),
```

Output with the fix applied:
```c
$ ./src/gfxdis/gfxdis.f3dex2 -d D619E013 88888888
{
    gsSPDmaRead(0x0678, 0x88888888, 0x0014),
}
```


Backported from the following libgfxd PR:
https://github.com/glankk/libgfxd/pull/12